### PR TITLE
feat: add gesture for side menu

### DIFF
--- a/lib/pages/app_wrapper.dart
+++ b/lib/pages/app_wrapper.dart
@@ -98,42 +98,58 @@ class _AppWrapperState extends State<AppWrapper> {
         return Stack(
           children: [
             // Main content
-            AnimatedContainer(
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeInOut,
-              transform: Matrix4.translationValues(
-                  _isSideMenuOpened ? _sideMenuWidth : 0, 0, 0),
-              child: Scaffold(
-                floatingActionButton: state.user != null
-                    ? floattingActionsButtons.elementAt(appState.pageIndex)
-                    : null,
-                floatingActionButtonLocation:
-                    FloatingActionButtonLocation.endFloat,
-                backgroundColor: getTheme(context).surface,
-                appBar: appBar,
-                body: body!,
-                bottomNavigationBar: BottomNavigation(
-                  destinations: navItems,
-                  currentPageIndex: appState.pageIndex,
-                  onTap: (index) {
-                    context.read<AppCubit>().changePageIndex(index: index);
-                  },
+            GestureDetector(
+              onHorizontalDragEnd: (details) {
+                // Right swipe to open menu
+                if (details.primaryVelocity! > 0 && !_isSideMenuOpened) {
+                  setState(() {
+                    _isSideMenuOpened = true;
+                  });
+                }
+                // Left swipe to close menu
+                else if (details.primaryVelocity! < 0 && _isSideMenuOpened) {
+                  setState(() {
+                    _isSideMenuOpened = false;
+                  });
+                }
+              },
+              child: AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+                transform: Matrix4.translationValues(
+                    _isSideMenuOpened ? _sideMenuWidth : 0, 0, 0),
+                child: Scaffold(
+                  floatingActionButton: state.user != null
+                      ? floattingActionsButtons.elementAt(appState.pageIndex)
+                      : null,
+                  floatingActionButtonLocation:
+                      FloatingActionButtonLocation.endFloat,
+                  backgroundColor: getTheme(context).surface,
+                  appBar: appBar,
+                  body: body!,
+                  bottomNavigationBar: BottomNavigation(
+                    destinations: navItems,
+                    currentPageIndex: appState.pageIndex,
+                    onTap: (index) {
+                      context.read<AppCubit>().changePageIndex(index: index);
+                    },
+                  ),
                 ),
               ),
             ),
 
             // Side menu
-            if (menuItems[appState.pageIndex] != null) 
-            AnimatedContainer(
-              duration: const Duration(milliseconds: 300),
-              curve: Curves.easeInOut,
-              width: _sideMenuWidth,
-              transform: Matrix4.translationValues(
-                  _isSideMenuOpened ? 0 : -_sideMenuWidth, 0, 0),
-              child: SideMenu(
-                items: menuItems[appState.pageIndex]!,
+            if (menuItems[appState.pageIndex] != null)
+              AnimatedContainer(
+                duration: const Duration(milliseconds: 300),
+                curve: Curves.easeInOut,
+                width: _sideMenuWidth,
+                transform: Matrix4.translationValues(
+                    _isSideMenuOpened ? 0 : -_sideMenuWidth, 0, 0),
+                child: SideMenu(
+                  items: menuItems[appState.pageIndex]!,
+                ),
               ),
-            ),
           ],
         );
       });

--- a/lib/pages/app_wrapper.dart
+++ b/lib/pages/app_wrapper.dart
@@ -138,6 +138,22 @@ class _AppWrapperState extends State<AppWrapper> {
               ),
             ),
 
+            // Overlay to detect taps outside the menu (only visible when menu is open)
+            if (_isSideMenuOpened)
+              Positioned.fill(
+                left: _sideMenuWidth,
+                child: GestureDetector(
+                  onTap: () {
+                    setState(() {
+                      _isSideMenuOpened = false;
+                    });
+                  },
+                  child: Container(
+                    color: Colors.transparent,
+                  ),
+                ),
+              ),
+
             // Side menu
             if (menuItems[appState.pageIndex] != null)
               AnimatedContainer(

--- a/lib/pages/auth/login_or_register_modal.dart
+++ b/lib/pages/auth/login_or_register_modal.dart
@@ -21,11 +21,17 @@ class LoginOrRegisterModal extends StatefulWidget {
 class _LoginOrRegisterModalState extends State<LoginOrRegisterModal> {
   String? email;
   String? password;
+  String? errorMessage;
   int _step = 0;
   @override
   Widget build(BuildContext context) {
     return BlocListener<AuthBloc, AuthState>(
       listener: (BuildContext context, AuthState state) async {
+        if (state is AuthError) {
+          setState(() {
+            errorMessage = state.message;
+          });
+        }
         if (state is LoggedIn) {
           if (!context.mounted) return;
           widget.onAuthSuccess();
@@ -58,6 +64,7 @@ class _LoginOrRegisterModalState extends State<LoginOrRegisterModal> {
                   _step = 1;
                 });
               },
+              errorMessage: errorMessage,
             );
           case 3:
             return RegisterEmail(

--- a/lib/pages/auth/screens/login.dart
+++ b/lib/pages/auth/screens/login.dart
@@ -12,8 +12,9 @@ import 'package:icons_plus/icons_plus.dart';
 
 class Login extends StatefulWidget {
   final VoidCallback onAuthSuccess;
-  const Login({super.key, this.cancelCallback, required this.onAuthSuccess});
+  const Login({super.key, this.cancelCallback, required this.onAuthSuccess, this.errorMessage});
   final VoidCallback? cancelCallback;
+  final String? errorMessage;
 
   @override
   State<Login> createState() => _LoginState();
@@ -23,7 +24,6 @@ class _LoginState extends State<Login> with SingleTickerProviderStateMixin {
   late AnimationController _animationController;
   final _animationDuration = const Duration(milliseconds: 250);
   final TextEditingController _emailController = TextEditingController();
-  String? _errorMessage;
   final TextEditingController _passwordController = TextEditingController();
 
   @override
@@ -44,11 +44,6 @@ class _LoginState extends State<Login> with SingleTickerProviderStateMixin {
   Widget build(BuildContext context) {
     return BlocListener<AuthBloc, AuthState>(
       listener: (BuildContext context, AuthState state) async {
-        if (state is AuthError) {
-          setState(() {
-            _errorMessage = state.message;
-          });
-        }
         if (state is LoggedIn) {
           _animationController.reverseDuration = const Duration(
             milliseconds: 500,
@@ -146,7 +141,7 @@ class _LoginState extends State<Login> with SingleTickerProviderStateMixin {
                           obscureText: true,
                         ),
                       ),
-                      if (_errorMessage != null) ...[
+                      if (widget.errorMessage != null) ...[
                         SizedBox(
                           height: $constants.insets.xs,
                         ),
@@ -156,7 +151,7 @@ class _LoginState extends State<Login> with SingleTickerProviderStateMixin {
                           child: SizedBox(
                             width: getSize(context).width * 0.9,
                             child: Text(
-                              context.t.errors[_errorMessage] ??
+                              context.t.errors[widget.errorMessage] ??
                                   context.t.errors["unknown_error"]!,
                               style: getTextTheme(context)
                                   .labelSmall!


### PR DESCRIPTION
Close #20 
- Gesture for side menu
- display error message on login page (did not displayed since the addition of a bloc listener in the widget tree before)